### PR TITLE
Allow attribute selection in subgraph views

### DIFF
--- a/src/tracksdata/graph/_graph_view.py
+++ b/src/tracksdata/graph/_graph_view.py
@@ -35,6 +35,12 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
     sync : bool, default True
         Whether to automatically synchronize changes in the view.
         By default only the root graph is updated.
+    node_attr_keys : Sequence[str] | None, optional
+        Node attribute keys available in this view. If ``None`` all attributes from the
+        root graph are included.
+    edge_attr_keys : Sequence[str] | None, optional
+        Edge attribute keys available in this view. If ``None`` all attributes from the
+        root graph are included.
 
     Attributes
     ----------
@@ -81,6 +87,8 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
         node_map_to_root: dict[int, int],
         root: BaseGraph,
         sync: bool = True,
+        node_attr_keys: Sequence[str] | None = None,
+        edge_attr_keys: Sequence[str] | None = None,
     ) -> None:
         # Initialize RustWorkXGraph
         RustWorkXGraph.__init__(self, rx_graph=None)  # rx_graph is not used to avoid initialization
@@ -107,8 +115,8 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
 
         # making sure these are not used
         # they should be accessed through the root graph
-        self._node_attr_keys = None
-        self._edge_attr_keys = None
+        self._node_attr_keys = list(node_attr_keys) if node_attr_keys is not None else None
+        self._edge_attr_keys = list(edge_attr_keys) if edge_attr_keys is not None else None
 
         # use parent graph overlaps
         self._overlaps = None
@@ -221,14 +229,18 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
 
     @property
     def node_attr_keys(self) -> list[str]:
-        return self._root.node_attr_keys
+        """List of node attribute keys available in this view."""
+        return self._node_attr_keys if self._node_attr_keys is not None else self._root.node_attr_keys
 
     @property
     def edge_attr_keys(self) -> list[str]:
-        return self._root.edge_attr_keys
+        """List of edge attribute keys available in this view."""
+        return self._edge_attr_keys if self._edge_attr_keys is not None else self._root.edge_attr_keys
 
     def add_node_attr_key(self, key: str, default_value: Any) -> None:
         self._root.add_node_attr_key(key, default_value)
+        if self._node_attr_keys is not None:
+            self._node_attr_keys.append(key)
         # because attributes are passed by reference, we need don't need if both are rustworkx graphs
         if not self._is_root_rx_graph:
             if self.sync:
@@ -240,6 +252,8 @@ class GraphView(RustWorkXGraph, MappedGraphMixin):
 
     def add_edge_attr_key(self, key: str, default_value: Any) -> None:
         self._root.add_edge_attr_key(key, default_value)
+        if self._edge_attr_keys is not None:
+            self._edge_attr_keys.append(key)
         # because attributes are passed by reference, we need don't need if both are rustworkx graphs
         if not self._is_root_rx_graph:
             if self.sync:

--- a/src/tracksdata/graph/_rustworkx_graph.py
+++ b/src/tracksdata/graph/_rustworkx_graph.py
@@ -232,10 +232,30 @@ class RXFilter(BaseFilter):
                 if not _filter_func(attr):
                     rx_graph.remove_edge(src, tgt)
 
+        full_node_keys = list(self._graph.node_attr_keys)
+        if node_attr_keys is None:
+            node_attr_keys = full_node_keys
+        elif isinstance(node_attr_keys, str):
+            node_attr_keys = [node_attr_keys]
+        else:
+            node_attr_keys = list(node_attr_keys)
+        node_attr_keys = list(dict.fromkeys(node_attr_keys))
+
+        full_edge_keys = list(self._graph.edge_attr_keys)
+        if edge_attr_keys is None:
+            edge_attr_keys = full_edge_keys
+        elif isinstance(edge_attr_keys, str):
+            edge_attr_keys = [edge_attr_keys]
+        else:
+            edge_attr_keys = list(edge_attr_keys)
+        edge_attr_keys = list(dict.fromkeys(edge_attr_keys))
+
         graph_view = GraphView(
             rx_graph,
             node_map_to_root=dict(node_map.items()),
             root=self._graph,
+            node_attr_keys=node_attr_keys,
+            edge_attr_keys=edge_attr_keys,
         )
 
         return graph_view

--- a/src/tracksdata/graph/_sql_graph.py
+++ b/src/tracksdata/graph/_sql_graph.py
@@ -281,10 +281,32 @@ class SQLFilter(BaseFilter):
     ) -> "GraphView":
         from tracksdata.graph._graph_view import GraphView
 
+        if node_attr_keys is None:
+            node_attr_keys = list(self._graph.node_attr_keys)
+        elif isinstance(node_attr_keys, str):
+            node_attr_keys = [node_attr_keys]
+        else:
+            node_attr_keys = list(node_attr_keys)
+        node_attr_keys = list(dict.fromkeys(node_attr_keys))
+
+        if edge_attr_keys is None:
+            edge_attr_keys = list(self._graph.edge_attr_keys)
+        elif isinstance(edge_attr_keys, str):
+            edge_attr_keys = [edge_attr_keys]
+        else:
+            edge_attr_keys = list(edge_attr_keys)
+        edge_attr_keys = list(dict.fromkeys(edge_attr_keys))
+
+        node_query_keys = list(node_attr_keys)
+        if DEFAULT_ATTR_KEYS.NODE_ID not in node_query_keys:
+            node_query_keys.append(DEFAULT_ATTR_KEYS.NODE_ID)
+        if DEFAULT_ATTR_KEYS.T not in node_query_keys:
+            node_query_keys.append(DEFAULT_ATTR_KEYS.T)
+
         node_query = self._query_from_attr_keys(
             query=self._node_query,
             table=self._graph.Node,
-            attr_keys=node_attr_keys,
+            attr_keys=node_query_keys,
         )
 
         edge_query = self._query_from_attr_keys(
@@ -299,22 +321,22 @@ class SQLFilter(BaseFilter):
         )
 
         with Session(self._graph._engine) as session:
-            node_query = session.execute(node_query)
-            edge_query = session.execute(edge_query)
+            node_rows = session.execute(node_query).mappings().all()
+            edge_rows = session.execute(edge_query).mappings().all()
 
             node_map_to_root = {}
             node_map_from_root = {}
             rx_graph = rx.PyDiGraph()
 
-            for row in node_query.scalars().all():
-                data = {k: v for k, v in row.__dict__.items() if not k.startswith("_")}
+            for row in node_rows:
+                data = dict(row)
                 root_node_id = data.pop(DEFAULT_ATTR_KEYS.NODE_ID)
                 node_id = rx_graph.add_node(data)
                 node_map_to_root[node_id] = root_node_id
                 node_map_from_root[root_node_id] = node_id
 
-            for row in edge_query.scalars().all():
-                data = {k: v for k, v in row.__dict__.items() if not k.startswith("_")}
+            for row in edge_rows:
+                data = dict(row)
                 source_id = node_map_from_root[data.pop(DEFAULT_ATTR_KEYS.EDGE_SOURCE)]
                 target_id = node_map_from_root[data.pop(DEFAULT_ATTR_KEYS.EDGE_TARGET)]
                 rx_graph.add_edge(source_id, target_id, data)
@@ -323,6 +345,8 @@ class SQLFilter(BaseFilter):
             rx_graph=rx_graph,
             node_map_to_root=node_map_to_root,
             root=self._graph,
+            node_attr_keys=node_attr_keys,
+            edge_attr_keys=edge_attr_keys,
         )
 
         return graph

--- a/src/tracksdata/graph/filters/_base_filter.py
+++ b/src/tracksdata/graph/filters/_base_filter.py
@@ -1,6 +1,6 @@
 import abc
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import polars as pl
@@ -51,8 +51,8 @@ class BaseFilter(abc.ABC):
     @abc.abstractmethod
     def subgraph(
         self,
-        node_attr_keys: list[str] | None = None,
-        edge_attr_keys: list[str] | None = None,
+        node_attr_keys: Sequence[str] | str | None = None,
+        edge_attr_keys: Sequence[str] | str | None = None,
     ) -> "GraphView":
         """
         Get a subgraph of the graph resulting from the filter.

--- a/src/tracksdata/graph/filters/_indexed_filter.py
+++ b/src/tracksdata/graph/filters/_indexed_filter.py
@@ -64,6 +64,24 @@ class IndexRXFilter(RXFilter):
                 if not _filter_func(attr):
                     rx_graph.remove_edge(src, tgt)
 
+        full_node_keys = list(self._graph.node_attr_keys)
+        if node_attr_keys is None:
+            node_attr_keys = full_node_keys
+        elif isinstance(node_attr_keys, str):
+            node_attr_keys = [node_attr_keys]
+        else:
+            node_attr_keys = list(node_attr_keys)
+        node_attr_keys = list(dict.fromkeys(node_attr_keys))
+
+        full_edge_keys = list(self._graph.edge_attr_keys)
+        if edge_attr_keys is None:
+            edge_attr_keys = full_edge_keys
+        elif isinstance(edge_attr_keys, str):
+            edge_attr_keys = [edge_attr_keys]
+        else:
+            edge_attr_keys = list(edge_attr_keys)
+        edge_attr_keys = list(dict.fromkeys(edge_attr_keys))
+
         root = self._graph
         if hasattr(self._graph, "_root"):
             root = self._graph._root
@@ -72,6 +90,8 @@ class IndexRXFilter(RXFilter):
             rx_graph,
             node_map_to_root=dict(node_map.items()),
             root=root,
+            node_attr_keys=node_attr_keys,
+            edge_attr_keys=edge_attr_keys,
         )
 
         return graph_view


### PR DESCRIPTION
## Summary
- allow selecting node and edge attributes when building subgraphs
- track view-specific attribute keys and update them on new key creation
- implement attribute-aware subgraphing for SQLGraph, RustWorkXGraph and indexed filters
- expose node_attr_keys and edge_attr_keys in GraphView constructor

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /usr/local/bin/pytest src/` *(fails: ModuleNotFoundError: No module named 'ctc_metrics')*


------
https://chatgpt.com/codex/tasks/task_e_68abf6a47344832297a99fb67fc32261